### PR TITLE
check cb

### DIFF
--- a/lib/Mojo/Reactor/EV.pm
+++ b/lib/Mojo/Reactor/EV.pm
@@ -44,9 +44,9 @@ sub watch {
     my $cb = sub {
       my ($w, $revents) = @_;
       $self->_try('I/O watcher', $self->{io}{$fd}{cb}, 0)
-        if EV::READ & $revents;
+        if EV::READ & $revents && $self->{io}{$fd} && $self->{io}{$fd}{cb};
       $self->_try('I/O watcher', $self->{io}{$fd}{cb}, 1)
-        if EV::WRITE & $revents && $self->{io}{$fd};
+        if EV::WRITE & $revents && $self->{io}{$fd} && $self->{io}{$fd}{cb};
     };
     $io->{watcher} = EV::io($fd, $mode, $cb);
   }


### PR DESCRIPTION
### Summary
check cb before call cb

### Motivation
When rpc call timeout,  it will print error of ` Can't locate object method "" via package "Mojo::Reactor::EV" at lib/perl5/Mojo/Reactor/Poll.pm line 143.`

