### PR TITLE
fix error: Use of strings with code points over 0xFF as arguments to bitwise and (&) operator is not allowed

### DIFF
--- a/lib/Mojo/JSON.pm
+++ b/lib/Mojo/JSON.pm
@@ -251,7 +251,7 @@ sub _encode_value {
   # Number
   no warnings 'numeric';
   return $value
-    if length((my $dummy = '') & $value)
+    if !utf8::is_utf8($value) && length((my $dummy = '') & $value)
     && 0 + $value eq $value
     && $value * 0 == 0;
 


### PR DESCRIPTION
### Summary
fix error: Use of strings with code points over 0xFF as arguments to bitwise and (&) operator is not allowed

### Motivation
EXPLAIN WHY YOU BELIEVE THESE CHANGES ARE NECESSARY HERE

### References
LIST RELEVANT ISSUES, PULL REQUESTS AND IRC/MAILING-LIST DISCUSSIONS HERE